### PR TITLE
Fix deprecated Buffer() constructor

### DIFF
--- a/src/apdu.js
+++ b/src/apdu.js
@@ -67,7 +67,7 @@ Apdu.prototype.toByteArray = function() {
 };
 
 Apdu.prototype.toBuffer = function() {
-    return new Buffer(this.bytes);
+    return Buffer.from(this.bytes);
 };
 
 module.exports = Apdu;


### PR DESCRIPTION
## Summary
- Replace `new Buffer()` with `Buffer.from()` in `toBuffer()` method
- The `Buffer()` constructor has been deprecated since Node.js v6.0.0

## Test Plan
- [x] Verified fix by running with `node --throw-deprecation` flag
- [x] No deprecation warnings thrown after fix

Fixes #1