### PR TITLE
Fix module system inconsistency

### DIFF
--- a/src/apdu.js
+++ b/src/apdu.js
@@ -70,4 +70,4 @@ Apdu.prototype.toBuffer = function() {
     return Buffer.from(this.bytes);
 };
 
-module.exports = Apdu;
+export default Apdu;


### PR DESCRIPTION
## Summary
- Replace CommonJS `module.exports` with ES Module `export default`
- The file was mixing ES6 imports with CommonJS exports

## Test Plan
- [x] Verified compilation works with Babel
- [x] Verified require works: `require('./lib/apdu.js').default`

Fixes #3