### PR TITLE
Add TypeScript type definitions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,8 @@
         "@babel/cli": "^7.26.4",
         "@babel/core": "^7.26.0",
         "@babel/preset-env": "^7.26.0",
+        "@types/node": "^25.0.3",
+        "typescript": "^5.9.3",
         "vitest": "^4.0.16"
       }
     },
@@ -2402,6 +2404,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "25.0.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.3.tgz",
+      "integrity": "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "4.0.16",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.16.tgz",
@@ -3615,6 +3627,27 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.5",
   "description": "",
   "main": "lib/apdu.js",
+  "types": "src/apdu.d.ts",
   "scripts": {
     "compile": "babel -d lib/ src/",
     "test": "vitest run",
@@ -27,6 +28,8 @@
     "@babel/cli": "^7.26.4",
     "@babel/core": "^7.26.0",
     "@babel/preset-env": "^7.26.0",
+    "@types/node": "^25.0.3",
+    "typescript": "^5.9.3",
     "vitest": "^4.0.16"
   }
 }

--- a/src/apdu.d.ts
+++ b/src/apdu.d.ts
@@ -1,0 +1,61 @@
+export interface ApduOptions {
+  /** Class byte (0x00-0xFF) */
+  cla: number;
+  /** Instruction byte */
+  ins: number;
+  /** Parameter 1 */
+  p1: number;
+  /** Parameter 2 */
+  p2: number;
+  /** Command data bytes */
+  data?: number[];
+  /** Expected response length */
+  le?: number;
+  /** Override automatic size calculation */
+  size?: number;
+}
+
+declare class Apdu {
+  /** The calculated or provided size of the APDU */
+  readonly size: number;
+  /** Class byte */
+  readonly cla: number;
+  /** Instruction byte */
+  readonly ins: number;
+  /** Parameter 1 */
+  readonly p1: number;
+  /** Parameter 2 */
+  readonly p2: number;
+  /** Command data bytes */
+  readonly data?: number[];
+  /** Expected response length */
+  readonly le: number;
+  /** Length of command data (Lc) */
+  readonly lc?: number;
+  /** Raw byte array of the APDU command */
+  readonly bytes: number[];
+
+  /**
+   * Creates a new APDU command
+   * @param options - Configuration options for the APDU command
+   */
+  constructor(options: ApduOptions);
+
+  /**
+   * Returns the APDU command as a lowercase hex string
+   */
+  toString(): string;
+
+  /**
+   * Returns the APDU command as an array of bytes
+   */
+  toByteArray(): number[];
+
+  /**
+   * Returns the APDU command as a Node.js Buffer
+   */
+  toBuffer(): Buffer;
+}
+
+export default Apdu;
+export { Apdu };


### PR DESCRIPTION
## Summary
- Add `apdu.d.ts` with full type definitions
- Add `types` field to package.json pointing to the declaration file
- TypeScript users now get autocomplete and type checking

## Test Plan
- [x] Verified types compile correctly with `tsc --noEmit`

Fixes #11