### PR TITLE
Add input validation

### DIFF
--- a/src/apdu.js
+++ b/src/apdu.js
@@ -2,14 +2,46 @@
 
 import hexify from 'hexify';
 
+function isValidByte(value) {
+  return typeof value === 'number' && value >= 0 && value <= 255;
+}
+
 function Apdu(obj) {
-  this.size = obj.size;
-  this.cla = obj.cla;
-  this.ins = obj.ins;
-  this.p1 = obj.p1;
-  this.p2 = obj.p2;
-  this.data = obj.data;
-  this.le = obj.le || 0;
+  if (!obj || typeof obj !== 'object') {
+    throw new TypeError('Options object is required');
+  }
+
+  const { cla, ins, p1, p2, data, le = 0, size } = obj;
+
+  if (!isValidByte(cla)) {
+    throw new RangeError('cla must be a byte value (0-255)');
+  }
+  if (!isValidByte(ins)) {
+    throw new RangeError('ins must be a byte value (0-255)');
+  }
+  if (!isValidByte(p1)) {
+    throw new RangeError('p1 must be a byte value (0-255)');
+  }
+  if (!isValidByte(p2)) {
+    throw new RangeError('p2 must be a byte value (0-255)');
+  }
+
+  if (data !== undefined) {
+    if (!Array.isArray(data)) {
+      throw new TypeError('data must be an array of bytes');
+    }
+    if (data.some((b) => !isValidByte(b))) {
+      throw new RangeError('All data values must be bytes (0-255)');
+    }
+  }
+
+  this.size = size;
+  this.cla = cla;
+  this.ins = ins;
+  this.p1 = p1;
+  this.p2 = p2;
+  this.data = data;
+  this.le = le;
 
   // case 1
   if (!this.size && !this.data && !this.le) {

--- a/src/apdu.test.js
+++ b/src/apdu.test.js
@@ -129,4 +129,63 @@ describe('Apdu', () => {
       expect(buffer).toEqual(Buffer.from([0x00, 0xa4, 0x04, 0x00, 0x00]));
     });
   });
+
+  describe('validation', () => {
+    it('should throw TypeError if options is not an object', () => {
+      expect(() => new Apdu()).toThrow(TypeError);
+      expect(() => new Apdu(null)).toThrow(TypeError);
+      expect(() => new Apdu('string')).toThrow(TypeError);
+    });
+
+    it('should throw RangeError if cla is out of range', () => {
+      expect(() => new Apdu({ cla: -1, ins: 0xa4, p1: 0, p2: 0 })).toThrow(
+        RangeError
+      );
+      expect(() => new Apdu({ cla: 256, ins: 0xa4, p1: 0, p2: 0 })).toThrow(
+        RangeError
+      );
+    });
+
+    it('should throw RangeError if ins is out of range', () => {
+      expect(() => new Apdu({ cla: 0, ins: -1, p1: 0, p2: 0 })).toThrow(
+        RangeError
+      );
+      expect(() => new Apdu({ cla: 0, ins: 256, p1: 0, p2: 0 })).toThrow(
+        RangeError
+      );
+    });
+
+    it('should throw RangeError if p1 is out of range', () => {
+      expect(() => new Apdu({ cla: 0, ins: 0xa4, p1: -1, p2: 0 })).toThrow(
+        RangeError
+      );
+      expect(() => new Apdu({ cla: 0, ins: 0xa4, p1: 256, p2: 0 })).toThrow(
+        RangeError
+      );
+    });
+
+    it('should throw RangeError if p2 is out of range', () => {
+      expect(() => new Apdu({ cla: 0, ins: 0xa4, p1: 0, p2: -1 })).toThrow(
+        RangeError
+      );
+      expect(() => new Apdu({ cla: 0, ins: 0xa4, p1: 0, p2: 256 })).toThrow(
+        RangeError
+      );
+    });
+
+    it('should throw TypeError if data is not an array', () => {
+      expect(
+        () => new Apdu({ cla: 0, ins: 0xa4, p1: 0, p2: 0, data: 'string' })
+      ).toThrow(TypeError);
+    });
+
+    it('should throw RangeError if data contains invalid byte values', () => {
+      expect(
+        () => new Apdu({ cla: 0, ins: 0xa4, p1: 0, p2: 0, data: [256] })
+      ).toThrow(RangeError);
+      expect(
+        () => new Apdu({ cla: 0, ins: 0xa4, p1: 0, p2: 0, data: [-1] })
+      ).toThrow(RangeError);
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Add validation for options object and all byte values
- Clear error messages for invalid inputs
- 7 new test cases for validation

## Validation Added
- Options object must be provided
- cla, ins, p1, p2 must be valid byte values (0-255)
- data must be an array of valid bytes if provided

## Test Plan
- [x] All 16 tests pass
- [x] ESLint passes
- [x] Prettier formatting correct

Fixes #17