### PR TITLE
Fix .npmignore to include TypeScript types

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,5 @@
-src/
+src/apdu.test.js
+.github/
+.nvmrc
+.prettierrc
+eslint.config.js


### PR DESCRIPTION
## Summary
Fix critical bug where TypeScript type definitions would be excluded from published package.

## Problem
The `.npmignore` contained `src/` which excluded the entire source directory, including `src/apdu.d.ts` (the TypeScript types referenced in package.json).

## Solution
Update `.npmignore` to exclude only:
- Test files
- Config/dev files

Fixes #26